### PR TITLE
2.0 fix test

### DIFF
--- a/Lib/Routing/Route/I18nRoute.php
+++ b/Lib/Routing/Route/I18nRoute.php
@@ -76,7 +76,11 @@ class I18nRoute extends CakeRoute {
 		if (empty($url['lang'])) {
 			$url['lang'] = Configure::read('Config.language');
 		}
-		return preg_replace('#/' . DEFAULT_LANGUAGE . '/#', '/', parent::match($url));
+		$parentMatch = parent::match($url);
+		if(!$parentMatch) {
+			return false;
+		}
+		return preg_replace('#/' . DEFAULT_LANGUAGE . '/#', '/', $parentMatch);
 	}
 
 /**


### PR DESCRIPTION
preg_replace won't return false. Check parent::match before using
preg_replace. Lib/I18nRoute test passes 6/6.
