### PR TITLE
Fixed an issue where lang code was removed from generated routes

### DIFF
--- a/Lib/Routing/Route/I18nRoute.php
+++ b/Lib/Routing/Route/I18nRoute.php
@@ -80,7 +80,11 @@ class I18nRoute extends CakeRoute {
 		if(!$parentMatch) {
 			return false;
 		}
-		return preg_replace('#/' . DEFAULT_LANGUAGE . '/#', '/', $parentMatch);
+
+		if ($this->__shouldStripDefaultLanguageOnMatch()) {
+			$parentMatch = preg_replace('#/' . DEFAULT_LANGUAGE . '/#', '/', $parentMatch);
+		}
+		return $parentMatch;
 	}
 
 /**
@@ -104,4 +108,17 @@ class I18nRoute extends CakeRoute {
 		}
 		return $params;
 	}
+
+/**
+ * Whether the default language code should be removed from the matched url
+ *
+ * @return boolean
+ */
+	private function __shouldStripDefaultLanguageOnMatch() {
+		$hasNamedParam = strpos($this->template, ':lang') !== false;
+		$hasHardcodedDefaultLang = strpos($this->template, '/' . DEFAULT_LANGUAGE . '/') !== false;
+
+		return !($hasNamedParam || $hasHardcodedDefaultLang);
+	}
+
 }

--- a/Test/Case/Lib/I18nRouteTest.php
+++ b/Test/Case/Lib/I18nRouteTest.php
@@ -149,6 +149,23 @@ class I18nRouteTestCase extends CakeTestCase {
 		$this->assertEquals($result, $expected);
 	}
 
+	public function testMatch_ShouldNotRemoveDefaultLangWhenContainedInTemplate() {
+		$route = new I18nRoute('/:lang/pages/*', array('controller' => 'pages', 'action' => 'display'));
+		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home', 'lang' => $this->__defaultLang));
+		$this->assertEquals('/' . $this->__defaultLang . '/pages/home', $result);
+	}
+
+	public function testMatch_ShouldNotRemoveDefaultLangWhenUsedInRouteContent() {
+		$routeStartsChunk = '/' . $this->__defaultLang . '/pages';
+		$route = new I18nRoute(
+			$routeStartsChunk . '/*',
+			array('controller' => 'pages', 'action' => 'display', 'lang' => $this->__defaultLang),
+			array('disableAutoNamedLang' => true)
+		);
+		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home', 'lang' => $this->__defaultLang));
+		$this->assertEquals($routeStartsChunk . '/home', $result);
+	}
+
 /**
  * Testing pagination urls with translation
  *


### PR DESCRIPTION
... for the default language, routes with a lang code inside did not
contain the lang for default language after matching whereas they should
