### PR TITLE
Fixed strict warning in flagImage method

### DIFF
--- a/View/Helper/I18nHelper.php
+++ b/View/Helper/I18nHelper.php
@@ -97,7 +97,8 @@ class I18nHelper extends AppHelper {
 		}
 
 		if (strpos($lang, '-') !== false) {
-			$flag = array_pop(explode('-', $lang));
+			$pieces = explode('-', $lang);
+			$flag = array_pop($pieces);
 		}
 
 		$result = $this->Html->image($options['basePath'] . $flag . '.png');


### PR DESCRIPTION
Explode returns a value when array_pop is expecting a reference
